### PR TITLE
Fixed issue 9 - remove references to expired .tech domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,17 +14,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
     <!-- OpenGraph Meta Tags. -->
-    <meta property="og:url" content="https://openwilma.tech/">
+    <meta property="og:url" content="https://openwilma.testausserveri.fi/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="OpenWilma">
     <meta property="og:description" content="Our goal is to reverse engineer Wilma's client apps to create public and open-source client libraries. OpenWilma libraries allow interacting with Wilma API and creating your own Wilma enabledapplications using simple and secure libraries.">
-    <meta property="og:image" content="https://openwilma.tech/assets/openwilma_icon_bluebg.png">
+    <meta property="og:image" content="https://openwilma.testausserveri.fi/assets/openwilma_icon_bluebg.png">
     <!-- Twitter Meta Tags -->
-    <meta property="twitter:url" content="https://openwilma.tech/">
+    <meta property="twitter:url" content="https://openwilma.testausserveri.fi/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="OpenWilma">
     <meta name="twitter:description" content="Our goal is to reverse engineer Wilma's client apps to create public and open-source client libraries. OpenWilma libraries allow interacting with Wilma API and creating your own Wilma enabledapplications using simple and secure libraries.">
-    <meta name="twitter:image" content="https://openwilma.tech/assets/openwilma_icon_bluebg.png">
+    <meta name="twitter:image" content="https://openwilma.testausserveri.fi/assets/openwilma_icon_bluebg.png">
 </head>
 
 <body>


### PR DESCRIPTION
Replaced instances of "openwilma.tech" with "openwilma.testausserveri.fi"

lines:
-17
-21
-23
-27